### PR TITLE
Network updates and other improvements

### DIFF
--- a/behavior_graph.py
+++ b/behavior_graph.py
@@ -538,7 +538,8 @@ def gather_nodes(ob, ob_idx, slot, slot_idx, export_settings, events, variables,
             if not isinstance(node, BGNode):
                 continue
 
-            print(f'Gathering {ob.name}-{slot.graph.name}-{node.name}')
+            node_name = node.name if not node.label else node.label
+            print(f'Gathering {ob.name}-{slot.graph.name}-{node_name}')
 
             prefix = f"{ob.name}_{ob_idx}_{slot.graph.name}_{slot_idx}"
             node_data = {
@@ -600,7 +601,7 @@ def gather_nodes(ob, ob_idx, slot, slot_idx, export_settings, events, variables,
             nodes.append(node_data)
 
         except Exception as e:
-            export_report.append(f'ERROR: {ob.name}/{slot.graph.name}/{node.name}: {e}')
+            export_report.append(f'ERROR: {ob.name}/{slot.graph.name}/{node_name}: {e}')
 
     return nodes
 

--- a/behavior_graph.py
+++ b/behavior_graph.py
@@ -502,17 +502,25 @@ def gather_events_and_variables(export_settings):
     events = {}
     variables = {}
 
+    # Graph variables
     for graph in bpy.data.node_groups:
         get_object_variables(graph, variables, export_settings)
 
+    # Scene variables
     get_object_variables(bpy.context.scene, variables, export_settings)
+
+    # Object variables
     for ob in bpy.context.view_layer.objects:
         get_object_variables(ob, variables, export_settings)
 
+    # Graph Custom Events
     for graph in bpy.data.node_groups:
         get_object_custom_events(graph, events, export_settings)
 
+    # Scene Custom Events
     get_object_custom_events(bpy.context.scene, events, export_settings)
+
+    # Object Custom Events
     for ob in bpy.context.view_layer.objects:
         get_object_custom_events(ob, events, export_settings)
 

--- a/behavior_graph.py
+++ b/behavior_graph.py
@@ -8,7 +8,7 @@ from bpy.types import Node, NodeTree, NodeReroute, NodeSocketString
 from bpy.utils import register_class, unregister_class
 from nodeitems_utils import NodeCategory, NodeItem, register_node_categories, unregister_node_categories
 from io_hubs_addon.io.utils import gather_property
-from .utils import get_socket_value, type_to_socket, resolve_input_link, resolve_output_link, get_variable_value
+from .utils import get_socket_value, type_to_socket, resolve_input_link, resolve_output_link, get_variable_value, get_prefs
 from .consts import CUSTOM_CATEGORY_NODES, DEPRECATED_NODES, CATEGORY_COLORS
 
 auto_casts = {
@@ -413,10 +413,15 @@ def create_node_class(node_data):
         def init(self, context):
             super().init(context)
 
-            if node_data["category"] in CATEGORY_COLORS:
-                self.color = CATEGORY_COLORS[node_data["category"]]
+            self.category = node_data["category"]
+            if self.category == "Networking":
+                self.color = get_prefs().network_node_color
             else:
-                self.color = CATEGORY_COLORS["None"]
+                if self.category in CATEGORY_COLORS:
+                    self.color = CATEGORY_COLORS[self.category]
+                else:
+                    self.color = CATEGORY_COLORS["None"]
+
 
             for input_data in node_data["inputs"]:
 

--- a/components/grabbable.py
+++ b/components/grabbable.py
@@ -12,7 +12,7 @@ class Grabbable(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'VIEW_PAN',
-        'deps': ['rigidbody', 'networked-transform'],
+        'deps': ['rigidbody', 'networked-object-properties'],
         'version': (1, 0, 0)
     }
 
@@ -21,6 +21,12 @@ class Grabbable(HubsComponent):
 
     hand: BoolProperty(
         name="By Hand", description="Can be grabbed by VR hands", default=True)
+
+    @classmethod
+    def init(cls, obj):
+        from .networked_object_properties import NetworkedObjectProperties
+        cmp = getattr(obj, NetworkedObjectProperties.get_id())
+        cmp.transform = True
 
 
 def register():

--- a/components/grabbable.py
+++ b/components/grabbable.py
@@ -24,6 +24,8 @@ class Grabbable(HubsComponent):
 
     @classmethod
     def init(cls, obj):
+        obj.hubs_component_list.items.get('rigidbody').isDependency = True
+        obj.hubs_component_list.items.get('networked-object-properties').isDependency = True
         from .networked_object_properties import NetworkedObjectProperties
         cmp = getattr(obj, NetworkedObjectProperties.get_id())
         cmp.transform = True

--- a/components/networked_animation.py
+++ b/components/networked_animation.py
@@ -1,5 +1,5 @@
 from io_hubs_addon.components.hubs_component import HubsComponent
-from io_hubs_addon.components.types import Category, NodeType, PanelType
+from io_hubs_addon.components.types import NodeType, PanelType
 from ..utils import do_register, do_unregister
 
 
@@ -7,12 +7,10 @@ class NetworkedAnimation(HubsComponent):
     _definition = {
         'name': 'networked-animation',
         'display_name': 'BG Networked Animation',
-        'category': Category.OBJECT,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'RENDER_ANIMATION',
-        'version': (1, 0, 0),
-        'deps': ['networked']
+        'version': (1, 0, 0)
     }
 
     def draw(self, context, layout, panel):

--- a/components/networked_behavior.py
+++ b/components/networked_behavior.py
@@ -2,10 +2,9 @@ import bpy
 from bpy.types import PropertyGroup
 from bpy.props import EnumProperty, CollectionProperty, StringProperty, IntProperty, FloatProperty, BoolProperty, FloatVectorProperty
 from io_hubs_addon.components.hubs_component import HubsComponent
-from io_hubs_addon.components.types import Category, NodeType, PanelType
-from io_hubs_addon.io.utils import gather_property, gather_vec_property, gather_color_property
-from ..utils import do_register, do_unregister
-from ..ui import update_nodes
+from io_hubs_addon.components.types import NodeType, PanelType
+from io_hubs_addon.io.utils import gather_vec_property
+from ..utils import do_register, do_unregister, gather_object_property, update_nodes
 
 NETWORKED_TYPES = [
     ("boolean", "Boolean", "Boolean"),
@@ -110,6 +109,7 @@ class NetworkedBehaviorPropList(bpy.types.UIList):
 
 
 def get_value(prop, export_settings):
+    value = None
     if prop.type == "integer":
         value = prop.defaultInt
     elif prop.type == "boolean":
@@ -120,6 +120,10 @@ def get_value(prop, export_settings):
         value = prop.defaultString
     elif prop.type == "vec3":
         value = gather_vec_property(export_settings, prop, prop, "defaultVec3")
+    elif prop.type == "entity":
+        value = gather_object_property(export_settings, prop.defaultEntity)
+    elif prop.type == "animationAction":
+        value = prop.defaultAnimationAction
 
     return value
 
@@ -128,12 +132,10 @@ class NetworkedBehavior(HubsComponent):
     _definition = {
         'name': 'networked-behavior',
         'display_name': 'BG Networked Behavior',
-        'category': Category.OBJECT,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'NODETREE',
-        'version': (1, 0, 0),
-        'deps': ['networked']
+        'version': (1, 0, 0)
     }
 
     props_list: CollectionProperty(

--- a/components/networked_material.py
+++ b/components/networked_material.py
@@ -1,5 +1,5 @@
 from io_hubs_addon.components.hubs_component import HubsComponent
-from io_hubs_addon.components.types import Category, NodeType, PanelType
+from io_hubs_addon.components.types import NodeType, PanelType
 from ..utils import do_register, do_unregister
 
 
@@ -7,7 +7,6 @@ class NetworkedMaterial(HubsComponent):
     _definition = {
         'name': 'networked-material',
         'display_name': 'BG Networked Material',
-        'category': Category.OBJECT,
         'node_type': NodeType.MATERIAL,
         'panel_type': [PanelType.MATERIAL],
         'icon': 'MATERIAL_DATA',

--- a/components/networked_object_material.py
+++ b/components/networked_object_material.py
@@ -1,5 +1,5 @@
 from io_hubs_addon.components.hubs_component import HubsComponent
-from io_hubs_addon.components.types import Category, NodeType, PanelType
+from io_hubs_addon.components.types import NodeType, PanelType
 from ..utils import do_register, do_unregister
 
 
@@ -7,12 +7,10 @@ class NetworkedObjectMaterial(HubsComponent):
     _definition = {
         'name': 'networked-object-material',
         'display_name': 'BG Networked Object Material',
-        'category': Category.OBJECT,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'MATERIAL_DATA',
-        'version': (1, 0, 0),
-        'deps': ['networked']
+        'version': (1, 0, 0)
     }
 
     def draw(self, context, layout, panel):

--- a/components/networked_object_properties.py
+++ b/components/networked_object_properties.py
@@ -1,5 +1,5 @@
 from io_hubs_addon.components.hubs_component import HubsComponent
-from io_hubs_addon.components.types import Category, NodeType, PanelType
+from io_hubs_addon.components.types import NodeType, PanelType
 from ..utils import do_register, do_unregister
 import bpy
 
@@ -7,13 +7,11 @@ import bpy
 class NetworkedObjectProperties(HubsComponent):
     _definition = {
         'name': 'networked-object-properties',
-        'display_name': 'BG Networked Object Properties',
-        'category': Category.OBJECT,
+        'display_name': 'BG Networked Object',
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'EMPTY_AXIS',
-        'version': (1, 0, 0),
-        'deps': ['networked']
+        'version': (1, 0, 0)
     }
 
     visible: bpy.props.BoolProperty(

--- a/components/networked_transform.py
+++ b/components/networked_transform.py
@@ -10,8 +10,7 @@ class NetworkedTransform(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'EMPTY_AXIS',
-        'version': (1, 0, 0),
-        'deps': ['networked']
+        'version': (1, 0, 0)
     }
 
 

--- a/components/rigid_body.py
+++ b/components/rigid_body.py
@@ -136,6 +136,10 @@ class RigidBody(HubsComponent):
         layout.prop(self, "angularFactor")
         layout.prop(self, "gravity")
 
+    @classmethod
+    def init(cls, obj):
+        obj.hubs_component_list.items.get('physics-shape').isDependency = True
+
 
 def register():
     do_register(RigidBody)

--- a/components/rigid_body.py
+++ b/components/rigid_body.py
@@ -21,7 +21,7 @@ class RigidBody(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'PHYSICS',
-        'deps': ['physics-shape', 'networked'],
+        'deps': ['physics-shape'],
         'version': (1, 0, 0)
     }
 

--- a/consts.py
+++ b/consts.py
@@ -1,0 +1,151 @@
+# Nodes that are deprecated and are replaced with hardcoded nodes but we still load the nodes
+# from the JSON as we want the to work for backwards compatibility but we don't want them to show in
+# the categories
+from .components import networked_animation, networked_behavior, networked_transform, rigid_body, physics_shape
+from io_hubs_addon.components.definitions import text, video, audio, media_frame, visible
+DEPRECATED_NODES = [
+    "BGNode_hubs_material_set",
+    "BGNode_hubs_material_getColor",
+    "BGNode_hubs_material_setColor",
+    "BGNode_hubs_material_getMap",
+    "BGNode_hubs_material_setMap",
+    "BGNode_hubs_material_getTransparent",
+    "BGNode_hubs_material_setTransparent",
+    "BGNode_hubs_material_getOpacity",
+    "BGNode_hubs_material_setOpacity",
+    "BGNode_hubs_material_getAlphaMap",
+    "BGNode_hubs_material_setAlphaMap",
+    "BGNode_hubs_material_getToneMapped",
+    "BGNode_hubs_material_setToneMapped",
+    "BGNode_hubs_material_getEmissive",
+    "BGNode_hubs_material_setEmissive",
+    "BGNode_hubs_material_getEmissiveMap",
+    "BGNode_hubs_material_setEmissiveMap",
+    "BGNode_hubs_material_getEmissiveIntensity",
+    "BGNode_hubs_material_setEmissiveIntensity",
+    "BGNode_hubs_material_getRoughness",
+    "BGNode_hubs_material_setRoughness",
+    "BGNode_hubs_material_getRoughnessMap",
+    "BGNode_hubs_material_setRoughnessMap",
+    "BGNode_hubs_material_getMetalness",
+    "BGNode_hubs_material_setMetalness",
+    "BGNode_hubs_material_getMetalnessMap",
+    "BGNode_hubs_material_setMetalnessMap",
+    "BGNode_hubs_material_getLightMap",
+    "BGNode_hubs_material_setLightMap",
+    "BGNode_hubs_material_getLightMapIntensity",
+    "BGNode_hubs_material_setLightMapIntensity",
+    "BGNode_hubs_material_getAOMap",
+    "BGNode_hubs_material_setAOMap",
+    "BGNode_hubs_material_getAOMapIntensity",
+    "BGNode_hubs_material_setAOMapIntensity",
+    "BGNode_hubs_material_getNormalMap",
+    "BGNode_hubs_material_setNormalMap",
+    "BGNode_hubs_material_getWireframe",
+    "BGNode_hubs_material_setWireframe",
+    "BGNode_hubs_material_getFlatShading",
+    "BGNode_hubs_material_setFlatShading",
+    "BGNode_hubs_material_getFog",
+    "BGNode_hubs_material_setFog",
+    "BGNode_hubs_material_getDepthWrite",
+    "BGNode_hubs_material_setDepthWrite",
+    "BGNode_hubs_material_getalphaTest",
+    "BGNode_hubs_material_setalphaTest"
+]
+
+#  Nodes we want to be loaded from the JSON spec but we just want to change their categories
+CUSTOM_CATEGORY_NODES = ["BGNode_hubs_onPlayerJoined",
+                         "BGNode_hubs_onPlayerLeft",
+                         "BGNode_lifecycle_onStart",
+                         "BGNode_lifecycle_onEnd",
+                         "BGNode_lifecycle_onTick",
+                         "BGNode_hubs_entity_components_custom_tags_removeTag",
+                         "BGNode_hubs_entity_components_custom_tags_addTag",
+                         "BGNode_hubs_entity_components_custom_tags_hasTag",
+                         "BGNode_hubs_components_text_setText"]
+
+MATERIAL_PROPERTIES_ENUM = [
+    ("color", "Color", "Color"),
+    ("map", "Map", "Map"),
+    ("transparent", "Transparent", "Transparent"),
+    ("opacity", "Opacity", "Opacity"),
+    ("alphaMap", "AlphaMap", "AlphaMap"),
+    ("toneMapped", "ToneMapped", "ToneMapped"),
+    ("emissive", "Emissive", "Emissive"),
+    ("emissiveMap", "EmissiveMap", "EmissiveMap"),
+    ("emissiveIntensity", "EmissiveIntensity", "EmissiveIntensity"),
+    ("roughness", "Roughness", "Roughness"),
+    ("roughnessMap", "RoughnessMap", "RoughnessMap"),
+    ("metalness", "Metalness", "Metalness"),
+    ("metalnessMap", "MetalnessMap", "MetalnessMap"),
+    ("lightMap", "LightMap", "LightMap"),
+    ("lightMapIntensity", "LightMapIntensity", "LightMapIntensity"),
+    ("aoMap", "AOMap", "AOMap"),
+    ("aoMapIntensity", "AOMapIntensity", "AOMapIntensity"),
+    ("normalMap", "NormalMap", "NormalMap"),
+    ("wireframe", "Wireframe", "Wireframe"),
+    ("flatShading", "FlatShading", "FlatShading"),
+    ("fog", "Fog", "Fog"),
+    ("depthWrite", "DepthWrite", "DepthWrite"),
+    ("alphaTest", "AlphaTest", "AlphaTest")
+]
+
+MATERIAL_PROPERTIES_TO_TYPES = {
+    "color": "color",
+    "map": "texture",
+    "transparent": "boolean",
+    "opacity": "float",
+    "alphaMap": "texture",
+    "toneMapped": "boolean",
+    "emissive": "color",
+    "emissiveMap": "texture",
+    "emissiveIntensity": "float",
+    "roughness": "float",
+    "roughnessMap": "texture",
+    "metalness": "float",
+    "metalnessMap": "texture",
+    "lightMap": "texture",
+    "lightMapIntensity": "float",
+    "aoMap": "texture",
+    "aoMapIntensity": "float",
+    "normalMap": "texture",
+    "wireframe": "boolean",
+    "flatShading": "boolean",
+    "fog": "boolean",
+    "depthWrite": "boolean",
+    "alphaTest": "float"
+}
+
+CATEGORY_COLORS = {
+    "Event":  (0.6, 0.2, 0.2),
+    "Flow":  (0.2, 0.2, 0.2),
+    "Time":  (0.3, 0.3, 0.3),
+    "Action":  (0.2, 0.2, 0.6),
+    "None": (0.6, 0.6, 0.2),
+    "Networking": (0.0, 0.7, 0.7)
+}
+
+
+# Components that Get Entity Component support. Support for these need to be available in the Hubs client
+SUPPORTED_COMPONENTS = [
+    video.Video.get_name(),
+    audio.Audio.get_name(),
+    text.Text.get_name(),
+    networked_animation.NetworkedAnimation.get_name(),
+    rigid_body.RigidBody.get_name(),
+    physics_shape.PhysicsShape.get_name(),
+    networked_transform.NetworkedTransform.get_name(),
+    networked_behavior.NetworkedBehavior.get_name(),
+    media_frame.MediaFrame.get_name(),
+    visible.Visible.get_name()
+]
+
+# Components that Set Component property support. Support for these need to be available in the Hubs client
+SUPPORTED_PROPERTY_COMPONENTS = [
+    video.Video.get_name(),
+    audio.Audio.get_name(),
+    text.Text.get_name(),
+    rigid_body.RigidBody.get_name(),
+    media_frame.MediaFrame.get_name(),
+    visible.Visible.get_name(),
+]

--- a/nodes.py
+++ b/nodes.py
@@ -7,7 +7,7 @@ from .consts import MATERIAL_PROPERTIES_ENUM, MATERIAL_PROPERTIES_TO_TYPES, SUPP
 
 
 def update_networked_color(self, context):
-    if hasattr(self, "networked") and self.networked:
+    if hasattr(self, "networked") and self.networked or self.category == "Networking":
         self.color = get_prefs().network_node_color
     else:
         self.color = (0.2, 0.6, 0.2)
@@ -17,8 +17,14 @@ class BGNode():
     bl_label = "Behavior Graph Node"
     bl_icon = "NODE"
 
+    category: bpy.props.StringProperty()
+
     def init(self, context):
         self.use_custom_color = True
+
+    def refresh(self):
+        if self.category == "Networking":
+            update_networked_color(self, bpy.context)
 
     @classmethod
     def poll(cls, ntree):
@@ -53,7 +59,7 @@ class BGNetworked():
 
     def refresh(self):
         if hasattr(super(), "refresh") and callable(getattr(super(), "refresh")):
-            super().refresh(self)
+            super().refresh()
         update_networked_color(self, bpy.context)
 
     def gather_configuration(self, ob, variables, events, export_settings):

--- a/nodes.py
+++ b/nodes.py
@@ -664,10 +664,10 @@ def get_input_entity(node, context, ob=None):
             # but not on the socket so we pull the variable value directly from the list
             from_node = link.from_socket.node
             # This case should go away when we remove BGNode_variable_get
-            if from_node.bl_idname == "BGNode_variable_get" and ob:
+            if from_node.bl_idname == "BGNode_variable_get":
                 from_target = get_input_entity(from_node, context, ob)
                 target = from_target.bg_global_variables.get(from_node.variableName).defaultEntity
-            elif from_node.bl_idname == "BGNode_networkedVariable_get" and ob:
+            elif from_node.bl_idname == "BGNode_networkedVariable_get":
                 from_target = get_input_entity(from_node, context, ob)
                 target = from_target.bg_global_variables.get(from_node.prop_name).defaultEntity
             elif from_node.bl_idname == "BGNode_hubs_entity_properties":

--- a/nodes.py
+++ b/nodes.py
@@ -1443,7 +1443,6 @@ class BGNode_get_material_property(BGNode, Node):
 
     def gather_configuration(self, ob, variables, events, export_settings):
         return {
-            "networked": self.networked,
             "property": gather_property(export_settings, self, self, "property_name"),
             "type": MATERIAL_PROPERTIES_TO_TYPES[self.property_name]
         }

--- a/nodes.py
+++ b/nodes.py
@@ -1500,7 +1500,11 @@ class BGNode_animation_createAnimationAction(BGNetworked, BGActionNode, BGNode, 
         self.inputs.new("NodeSocketBool", "loop")
         self.inputs.new("NodeSocketBool", "clampWhenFinished")
         self.inputs.new("NodeSocketFloat", "weight")
+        weight = self.inputs.get("weight")
+        weight.default_value = 1
         self.inputs.new("NodeSocketFloat", "timeScale")
+        timeScale = self.inputs.get("timeScale")
+        timeScale.default_value = 1
         self.inputs.new("NodeSocketBool", "additiveBlending")
         self.outputs.new("BGHubsAnimationActionSocket", "action")
 
@@ -1570,6 +1574,8 @@ class BGNode_three_animation_setTimescale(BGNetworked, BGActionNode, BGNode, Nod
         super().init(context)
         self.inputs.new("BGHubsAnimationActionSocket", "action")
         self.inputs.new("NodeSocketFloat", "timeScale")
+        timeScale = self.inputs.get("timeScale")
+        timeScale.default_value = 1
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "networked")

--- a/nodes.py
+++ b/nodes.py
@@ -660,15 +660,17 @@ def get_input_entity(node, context, ob=None):
         target = entity_socket.target
         if node.inputs.get("entity").is_linked and len(entity_socket.links) > 0:
             link = entity_socket.links[0]
-            # When copying entities the variable is updated in the networked behavior list
-            # but not on the socket so we pull the variable value directly from the list
             from_node = link.from_socket.node
             # This case should go away when we remove BGNode_variable_get
             if from_node.bl_idname == "BGNode_variable_get":
                 from_target = get_input_entity(from_node, context, ob)
+                # When copying entities the variable is updated in the variables list
+                # but not on the socket so we pull the variable value directly from the list
                 target = from_target.bg_global_variables.get(from_node.variableName).defaultEntity
             elif from_node.bl_idname == "BGNode_networkedVariable_get":
                 from_target = get_input_entity(from_node, context, ob)
+                # When copying entities the variable is updated in the variables list
+                # but not on the socket so we pull the variable value directly from the list
                 target = from_target.bg_global_variables.get(from_node.prop_name).defaultEntity
             elif from_node.bl_idname == "BGNode_hubs_entity_properties":
                 from_target = get_input_entity(from_node, context, ob)
@@ -683,10 +685,17 @@ def get_input_entity(node, context, ob=None):
             elif entity_socket.entity_type == "scene":
                 target = context.scene
             elif entity_socket.entity_type == "graph":
-                if context.scene.bg_node_type == 'OBJECT':
-                    target = context.object.bg_active_graph
+                # When exporting we use the current exporting object as the target object
+                if ob:
+                    if type(ob) == bpy.types.Object:
+                        target = context.object.bg_active_graph
+                    else:
+                        target = context.scene.bg_active_graph
                 else:
-                    target = context.scene.bg_active_graph
+                    if context.scene.bg_node_type == 'OBJECT':
+                        target = context.object.bg_active_graph
+                    else:
+                        target = context.scene.bg_active_graph
 
     return target
 

--- a/nodes.py
+++ b/nodes.py
@@ -861,7 +861,7 @@ class BGNode_networkedVariable_set(BGNetworked, BGActionNode, BGNode, Node):
             value = {
                 self.prop_name: {
                     "type": prop.type,
-                    "value": get_variable_value(prop, export_settings)
+                    "value": get_variable_value(target, prop, export_settings)
                 }
             }
             update_gltf_network_dependencies(self, export_settings, target, NetworkedBehavior, value)

--- a/nodes.py
+++ b/nodes.py
@@ -1,10 +1,16 @@
 import bpy
 from bpy.props import PointerProperty, StringProperty
 from bpy.types import Node
-from io_hubs_addon.components.definitions import text, video, audio, media_frame, visible
-from .components import networked_animation, networked_behavior, networked_transform, rigid_body, physics_shape
 from io_hubs_addon.io.utils import gather_property
-from .utils import gather_object_property, get_socket_value, filter_on_components, filter_entity_type
+from .utils import gather_object_property, get_socket_value, filter_on_components, filter_entity_type, get_prefs, object_exists
+from .consts import MATERIAL_PROPERTIES_ENUM, MATERIAL_PROPERTIES_TO_TYPES, SUPPORTED_COMPONENTS, SUPPORTED_PROPERTY_COMPONENTS
+
+
+def update_networked_color(self, context):
+    if hasattr(self, "networked") and self.networked:
+        self.color = get_prefs().network_node_color
+    else:
+        self.color = (0.2, 0.6, 0.2)
 
 
 class BGNode():
@@ -37,18 +43,44 @@ class BGActionNode():
         BGFlowSocket.create(self.outputs)
 
 
+class BGNetworked():
+
+    networked: bpy.props.BoolProperty(default=True, update=update_networked_color)
+
+    def init(self, context):
+        super().init(context)
+        update_networked_color(self, context)
+
+    def refresh(self):
+        if hasattr(super(), "refresh") and callable(getattr(super(), "refresh")):
+            super().refresh(self)
+        update_networked_color(self, bpy.context)
+
+    def gather_configuration(self, ob, variables, events, export_settings):
+        return {
+            "networked": self.networked
+        }
+
+
+def on_entity_property_update(node, context):
+    if "entity" in node.outputs:
+        node.outputs.get("entity").target = node.target
+
+
 class BGEntityPropertyNode():
     entity_type: bpy.props.EnumProperty(
         name="",
         description="Target Entity",
         items=filter_entity_type,
+        update=on_entity_property_update,
         default=0
     )
 
     target: PointerProperty(
         name="Target",
         type=bpy.types.Object,
-        poll=filter_on_components
+        poll=filter_on_components,
+        update=on_entity_property_update
     )
 
     def draw_buttons(self, context, layout):
@@ -61,6 +93,8 @@ class BGEntityPropertyNode():
         target = ob if self.entity_type == "self" else self.target
         if not self.target and type(ob) == bpy.types.Scene:
             raise Exception('Empty entity cannot be used for Scene objects in this context')
+        elif not self.target and self.entity_type == "other":
+            raise Exception('Entity not set')
         else:
             return {
                 "target": gather_object_property(export_settings, target)
@@ -79,14 +113,9 @@ class BGEntityPropertyNode():
                 "value": gather_object_property(export_settings, input_socket.target)
             }
 
-    def get_target(self):
-        return self.target
-
-    def get_entity_type(self):
-        return self.entity_type
-
 
 entity_property_settings = {
+    "name": ("NodeSocketString", ""),
     "visible": ("NodeSocketBool", False),
     "position": ("NodeSocketVectorXYZ", [0.0, 0.0, 0.0]),
     "rotation": ("NodeSocketVectorEuler", [0.0, 0.0, 0.0]),
@@ -94,23 +123,22 @@ entity_property_settings = {
 }
 
 
-def update_target_property(self, context):
+def update_set_entity_property(self, context):
     if self.inputs and len(self.inputs) > 2:
-        self.outputs.remove(self.inputs[2])
+        self.inputs.remove(self.inputs[2])
 
-    # context can be null here sometimes so using the global context
-    entity_type = self.inputs.get("entity").entity_type
-    if entity_type == "self" and bpy.context.scene.bg_node_type == 'SCENE':
+    target = get_input_entity(self, bpy.context)
+    if not target:
         return
 
     setattr(self, "node_type",  "hubs/entity/set/" + self.targetProperty)
     (socket_type,
      default_value) = entity_property_settings[self.targetProperty]
-    sock = self.inputs.new(socket_type, self.targetProperty)
-    sock.default_value = default_value
+    socket = self.inputs.new(socket_type, self.targetProperty)
+    socket.default_value = default_value
 
 
-class BGHubsSetEntityProperty(BGActionNode, BGNode, Node):
+class BGHubsSetEntityProperty(BGNetworked, BGActionNode, BGNode, Node):
     bl_label = "Set Entity Property"
 
     node_type: bpy.props.StringProperty()
@@ -124,19 +152,39 @@ class BGHubsSetEntityProperty(BGActionNode, BGNode, Node):
             ("scale", "scale", "")
         ],
         default="visible",
-        update=update_target_property
+        update=update_set_entity_property
     )
 
     def init(self, context):
         super().init(context)
-        self.color = (0.2, 0.6, 0.2)
         self.inputs.new("BGHubsEntitySocket", "entity")
-        update_target_property(self, context)
+        update_set_entity_property(self, context)
 
     def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
         entity_type = self.inputs.get("entity").entity_type
         if (entity_type == "self" and context.scene.bg_node_type != 'SCENE') or entity_type != "self":
             layout.prop(self, "targetProperty")
+
+    def update_network_dependencies(self, ob, export_settings):
+        if self.networked:
+            target = get_input_entity(self, bpy.context, ob)
+            if not target:
+                raise Exception("Entity not set")
+            if not object_exists(target):
+                raise Exception(f"Entity {target.name} does not exist")
+            from .utils import update_gltf_network_dependencies
+            from .components import networked_object_properties
+            if self.targetProperty == "position" or self.targetProperty == "rotation" or self.targetProperty == "scale":
+                value = {
+                    "transform": True
+                }
+            elif self.targetProperty == "visible":
+                value = {
+                    self.targetProperty: True
+                }
+            update_gltf_network_dependencies(self, export_settings, target,
+                                             networked_object_properties.NetworkedObjectProperties, value)
 
 
 class BGNode_hubs_onInteract(BGEventNode, BGEntityPropertyNode, BGNode, Node):
@@ -269,38 +317,10 @@ class BGNode_flow_sequence(BGNode, Node):
         layout.prop(self, "numOutputs")
 
 
-def get_variable_target(node, context, ob=None):
-    target = None
-    entity_socket = node.inputs.get("entity")
-    if entity_socket:
-        target = entity_socket.target
-        if node.inputs.get("entity").is_linked and len(entity_socket.links) > 0:
-            link = entity_socket.links[0]
-            # When copying entities the variable is updated in the networked behavior  list
-            # but not on the socket so we pull the variable value directly from the list
-            node = link.from_socket.node
-            if node.bl_idname == "BGNode_variable_get" and ob:
-                target = ob.bg_global_variables.get(node.variableName).defaultEntity
-            else:
-                target = link.from_socket.target
-        else:
-            if entity_socket.entity_type == "object":
-                target = ob if ob else context.object
-            elif entity_socket.entity_type == "scene":
-                target = context.scene
-            elif entity_socket.entity_type == "graph":
-                if context.scene.bg_node_type == 'OBJECT':
-                    target = context.object.bg_active_graph
-                else:
-                    target = context.scene.bg_active_graph
-
-    return target
-
-
 def get_available_variables(self, context):
     get_available_variables.cached_enum = [("None", "None", "None")]
 
-    target = get_variable_target(self, context)
+    target = get_input_entity(self, context)
     if target:
         for var in target.bg_global_variables:
             get_available_variables.cached_enum.append((var.name, var.name, var.name))
@@ -313,39 +333,76 @@ def get_available_variables(self, context):
 get_available_variables.cached_enum = []
 
 
-def update_selected_variable_output(self, context):
-    # Remove previous socket
-    if self.outputs:
-        self.outputs.remove(self.outputs[0])
+def update_selected_variable(self, context):
+    isSetter = self.bl_idname == "BGNode_variable_set"
+
+    has_socket = False
+    old_type = "None"
+    if isSetter:
+        self.color = (0.2, 0.6, 0.2)
+        if "value" in self.inputs:
+            has_socket = True
+            from .utils import socket_to_type
+            old_type = socket_to_type[self.inputs.get("value").bl_idname]
+    else:
+        self.color = (0.6, 0.6, 0.2)
+        if "value" in self.outputs:
+            has_socket = True
+            from .utils import socket_to_type
+            old_type = socket_to_type[self.outputs.get("value").bl_idname]
 
     if not context:
         return
 
-    target = get_variable_target(self, context)
+    remove_sockets = True
+    target = get_input_entity(self, context)
+    if target:
+        has_var = self.variableName in target.bg_global_variables
+        var = target.bg_global_variables.get(self.variableName)
+        var_type = var.type if has_var else "None"
+        if var_type == old_type:
+            remove_sockets = False
+
+    if remove_sockets and has_socket:
+        if isSetter:
+            if "value" in self.inputs:
+                from .utils import socket_to_type
+                self.inputs.remove(self.inputs.get("value"))
+        elif "value" in self.outputs:
+            from .utils import socket_to_type
+            self.outputs.remove(self.outputs.get("value"))
 
     if not target:
         return
 
-    has_var = self.variableName in target.bg_global_variables
-    var_type = target.bg_global_variables.get(self.variableName).type if has_var else "None"
-
     # Create a new socket based on the selected variable type
     from .utils import type_to_socket
-    if var_type != "None":
-        self.outputs.new(type_to_socket[var_type], "value")
+    if var_type != "None" and old_type != var_type:
+        if isSetter:
+            socket = self.inputs.new(type_to_socket[var_type], "value")
+        else:
+            socket = self.outputs.new(type_to_socket[var_type], "value")
+            if var_type == "entity":
+                self.outputs.get("value").target = target.bg_global_variables.get(self.variableName).defaultEntity
         if var_type == "entity":
-            self.outputs[0].target = target.bg_global_variables.get(self.variableName).defaultEntity
+            socket.refresh = False
+
+    if isSetter:
+        if var and hasattr(var, "networked") and var.networked and var_type != "entity":
+            self.color = get_prefs().network_node_color
+
+    self.prop_type = var_type
 
 
 def getVariableId(self):
-    target = get_variable_target(self, bpy.context)
+    target = get_input_entity(self, bpy.context)
     if target and self.variableName in target.bg_global_variables:
         return target.bg_global_variables.find(self.variableName) + 1
     return 0
 
 
 def setVariableId(self, value):
-    target = get_variable_target(self, bpy.context)
+    target = get_input_entity(self, bpy.context)
     if not target or value == 0:
         self.variableName = 'None'
     elif value <= len(target.bg_global_variables):
@@ -368,43 +425,32 @@ class BGNode_variable_get(BGNode, Node):
         name="Variable",
         description="Variable",
         items=get_available_variables,
-        update=update_selected_variable_output,
+        update=update_selected_variable,
         get=getVariableId,
         set=setVariableId,
     )
 
     def init(self, context):
         super().init(context)
-        self.color = (0.2, 0.6, 0.2)
+        self.color = (0.6, 0.6, 0.2)
         self.inputs.new("BGHubsEntitySocket", "entity")
         entity = self.inputs.get("entity")
         entity.custom_type = "event_variable"
         entity.export = False
-        update_selected_variable_output(self, context)
+        update_selected_variable(self, context)
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "variableId")
 
     def refresh(self):
-        from .utils import socket_to_type
-        target = get_variable_target(self, bpy.context)
-        has_var = self.variableName in target.bg_global_variables
-        var_type = target.bg_global_variables.get(self.variableName).type if has_var else "None"
-        cur_type = socket_to_type[self.outputs.get(
-            "value").bl_idname] if self.outputs and len(self.outputs) > 1 else 'None'
-        if not has_var or var_type != cur_type:
-            if target and len(self.outputs) > 1 and len(self.outputs.get("value").links) > 0:
-                has_var = self.variableId in target.bg_global_variables
-                var_type = target.bg_global_variables.get(
-                    self.variableId).type if has_var else "None"
-                if self.outputs.get("value") != None and var_type != socket_to_type[self.outputs.get("value").bl_idname]:
-                    try:
-                        target.bg_active_graph.links.remove(self.outputs.get("value").links[0])
-                    except Exception as e:
-                        print(e)
+        update_selected_variable(self, bpy.context)
 
     def gather_configuration(self, ob, variables, events, export_settings):
-        target = get_variable_target(self, bpy.context, ob)
+        target = get_input_entity(self, bpy.context, ob)
+        if not target:
+            raise Exception("Entity not set")
+        if not object_exists(target):
+            raise Exception(f"Entity {target.name} does not exist")
         var_name = f"{target.name}_{self.variableName}"
         if self.variableName == 'None' or var_name not in variables:
             raise Exception(f'variable node: {self.variableName}[{var_name}],  id: "None"')
@@ -413,28 +459,6 @@ class BGNode_variable_get(BGNode, Node):
             return {
                 "variableId": variables[var_name]["id"]
             }
-
-
-def update_selected_variable_input(self, context):
-    # Remove previous socket
-    if self.inputs and len(self.inputs) > 2:
-        self.inputs.remove(self.inputs[2])
-
-    if not context:
-        return
-
-    target = get_variable_target(self, context)
-
-    if not target:
-        return
-
-    has_var = self.variableName in target.bg_global_variables
-    var_type = target.bg_global_variables.get(self.variableName).type if has_var else "None"
-
-    # Create a new socket based on the selected variable type
-    from .utils import type_to_socket
-    if var_type != "None":
-        self.inputs.new(type_to_socket[var_type], "value")
 
 
 class BGNode_variable_set(BGActionNode, BGNode, Node):
@@ -451,7 +475,7 @@ class BGNode_variable_set(BGActionNode, BGNode, Node):
         name="Value",
         description="Variable Value",
         items=get_available_variables,
-        update=update_selected_variable_input,
+        update=update_selected_variable,
         get=getVariableId,
         set=setVariableId,
     )
@@ -463,35 +487,20 @@ class BGNode_variable_set(BGActionNode, BGNode, Node):
         entity = self.inputs.get("entity")
         entity.custom_type = "event_variable"
         entity.export = False
-        update_selected_variable_input(self, context)
+        update_selected_variable(self, context)
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "variableId")
 
     def refresh(self):
-        from .utils import socket_to_type
-        target = get_variable_target(self, bpy.context)
-        if not target:
-            return
-
-        has_var = self.variableName in target.bg_global_variables
-        var_type = target.bg_global_variables.get(self.variableName).type if has_var else "None"
-        cur_type = socket_to_type[self.inputs.get(
-            "value").bl_idname] if self.inputs and len(self.inputs) > 2 else 'None'
-        if not has_var or var_type != cur_type:
-            update_selected_variable_input(self, bpy.context)
-            if target and len(self.inputs) > 2 and len(self.inputs.get("value").links) > 0:
-                has_var = self.variableId in target.bg_global_variables
-                var_type = target.bg_global_variables.get(
-                    self.variableId).type if has_var else "None"
-                if self.inputs.get("value") != None and var_type != socket_to_type[self.inputs.get("value").bl_idname]:
-                    try:
-                        target.bg_active_graph.links.remove(self.inputs.get("value").links[0])
-                    except Exception as e:
-                        print(e)
+        update_selected_variable(self, bpy.context)
 
     def gather_configuration(self, ob, variables, events, export_settings):
-        target = get_variable_target(self, bpy.context, ob)
+        target = get_input_entity(self, bpy.context, ob)
+        if not target:
+            raise Exception("Entity not set")
+        if not object_exists(target):
+            raise Exception(f"Entity {target.name} does not exist")
         var_name = f"{target.name}_{self.variableName}"
         if self.variableName == 'None' or var_name not in variables:
             raise Exception(f'variable node: {self.variableName}[{var_name}],  id: "None"')
@@ -504,7 +513,7 @@ class BGNode_variable_set(BGActionNode, BGNode, Node):
 
 def get_available_custom_events(self, context):
     get_available_custom_events.cached_enum = [("None", "None", "None")]
-    target = get_variable_target(self, context)
+    target = get_input_entity(self, context)
     if target:
         for var in target.bg_custom_events:
             get_available_custom_events.cached_enum.append((var.name, var.name, var.name))
@@ -518,14 +527,14 @@ get_available_custom_events.cached_enum = []
 
 
 def getCustomEventId(self):
-    target = get_variable_target(self, bpy.context)
+    target = get_input_entity(self, bpy.context)
     if target and self.customEventName in target.bg_custom_events:
         return target.bg_custom_events.find(self.customEventName) + 1
     return 0
 
 
 def setCustomEventId(self, value):
-    target = get_variable_target(self, bpy.context)
+    target = get_input_entity(self, bpy.context)
     if not target or value == 0:
         self.customEventName = 'None'
     elif value <= len(target.bg_custom_events):
@@ -566,10 +575,14 @@ class BGNode_customEvent_trigger(BGActionNode, BGNode, Node):
         self.customEventId = self.customEventId
 
     def gather_configuration(self, ob, variables, events, export_settings):
-        target = get_variable_target(self, bpy.context, ob)
+        target = get_input_entity(self, bpy.context, ob)
+        if not target:
+            raise Exception("Entity not set")
+        if not object_exists(target):
+            raise Exception(f"Entity {target.name} does not exist")
         event_name = f"{target.name}_{self.customEventName}"
         if self.customEventName == 'None' or event_name not in events:
-            raise Exception(f' custom event node: {self.variableName}[{event_name}],  id: "None"')
+            raise Exception(f' custom event node: {self.customEventName}[{event_name}],  id: "None"')
         else:
             print(f'custom event node: {self.customEventName}, id: {events[event_name]["id"]}')
             return {
@@ -609,10 +622,14 @@ class BGNode_customEvent_onTriggered(BGEventNode, BGNode, Node):
         self.customEventId = self.customEventId
 
     def gather_configuration(self, ob, variables, events, export_settings):
-        target = get_variable_target(self, bpy.context, ob)
+        target = get_input_entity(self, bpy.context, ob)
+        if not target:
+            raise Exception("Entity not set")
+        if not object_exists(target):
+            raise Exception(f"Entity {target.name} does not exist")
         event_name = f"{target.name}_{self.customEventName}"
         if self.customEventName == 'None' or event_name not in events:
-            raise Exception(f' custom event node: {self.variableName}[{event_name}],  id: "None"')
+            raise Exception(f' custom event node: {self.customEventName}[{event_name}],  id: "None"')
         else:
             print(f'custom event node: {self.customEventName}, id: {events[event_name]["id"]}')
             return {
@@ -621,12 +638,12 @@ class BGNode_customEvent_onTriggered(BGEventNode, BGNode, Node):
 
 
 def get_available_networkedBehavior_properties(self, context):
-    target = get_target(self, context)
-
     get_available_networkedBehavior_properties.cached_enum = [("None", "None", "None")]
-    if target and hasattr(target, "hubs_component_networked_behavior"):
-        for prop in target.hubs_component_networked_behavior.props_list:
-            get_available_networkedBehavior_properties.cached_enum.append((prop.name, prop.name, prop.name))
+
+    target = get_input_entity(self, context)
+    if target:
+        for var in target.bg_global_variables:
+            get_available_networkedBehavior_properties.cached_enum.append((var.name, var.name, var.name))
 
     return get_available_networkedBehavior_properties.cached_enum
 
@@ -636,167 +653,278 @@ def get_available_networkedBehavior_properties(self, context):
 get_available_networkedBehavior_properties.cached_enum = []
 
 
-def get_target(self, context):
+def get_input_entity(node, context, ob=None):
     target = None
-    entity_socket = self.inputs.get("entity")
+    entity_socket = node.inputs.get("entity")
     if entity_socket:
         target = entity_socket.target
-        if self.inputs.get("entity").is_linked and len(entity_socket.links) > 0:
+        if node.inputs.get("entity").is_linked and len(entity_socket.links) > 0:
             link = entity_socket.links[0]
-            target = link.from_socket.target
+            # When copying entities the variable is updated in the networked behavior list
+            # but not on the socket so we pull the variable value directly from the list
+            from_node = link.from_socket.node
+            # This case should go away when we remove BGNode_variable_get
+            if from_node.bl_idname == "BGNode_variable_get" and ob:
+                from_target = get_input_entity(from_node, context, ob)
+                target = from_target.bg_global_variables.get(from_node.variableName).defaultEntity
+            elif from_node.bl_idname == "BGNode_networkedVariable_get" and ob:
+                from_target = get_input_entity(from_node, context, ob)
+                target = from_target.bg_global_variables.get(from_node.prop_name).defaultEntity
+            elif from_node.bl_idname == "BGNode_hubs_entity_properties":
+                from_target = get_input_entity(from_node, context, ob)
+                target = from_target
+            else:
+                target = link.from_socket.target
         else:
-            entity_type = entity_socket.entity_type
-            if entity_type == "self":
-                target = context.object if context.scene.bg_node_type == 'OBJECT' else context.scene
+            if entity_socket.entity_type == '':
+                target = None
+            elif entity_socket.entity_type in ["object", "self"]:
+                target = ob if ob else context.object
+            elif entity_socket.entity_type == "scene":
+                target = context.scene
+            elif entity_socket.entity_type == "graph":
+                if context.scene.bg_node_type == 'OBJECT':
+                    target = context.object.bg_active_graph
+                else:
+                    target = context.scene.bg_active_graph
 
     return target
 
 
-def networkedBehavior_properties_updated(self, context):
-    target = get_target(self, context)
-    if not target or not hasattr(target, "hubs_component_networked_behavior"):
+def update_selected_networked_variable(self, context):
+    isSetter = self.bl_idname == "BGNode_networkedVariable_set"
+
+    has_socket = False
+    old_type = "None"
+    if isSetter:
+        self.color = (0.2, 0.6, 0.2)
+        if "value" in self.inputs:
+            has_socket = True
+            from .utils import socket_to_type
+            old_type = socket_to_type[self.inputs.get("value").bl_idname]
+    else:
+        self.color = (0.6, 0.6, 0.2)
+        if "value" in self.outputs:
+            has_socket = True
+            from .utils import socket_to_type
+            old_type = socket_to_type[self.outputs.get("value").bl_idname]
+
+    if not context:
         return
 
-    has_prop = self.prop_name in target.hubs_component_networked_behavior.props_list
-    prop_type = target.hubs_component_networked_behavior.props_list[self.prop_name].type if has_prop else "None"
+    remove_sockets = True
+    target = get_input_entity(self, context)
+    if target:
+        has_var = self.prop_name in target.bg_global_variables
+        var = target.bg_global_variables.get(self.prop_name)
+        var_type = var.type if has_var else "None"
+        if var_type == old_type:
+            remove_sockets = False
 
-    for socket_id in ["boolean", "float", "integer", "string", "vec3"]:
-        if socket_id in self.inputs:
-            self.inputs[socket_id].hide = not prop_type or prop_type != socket_id
-        if socket_id in self.outputs:
-            self.outputs[socket_id].hide = not prop_type or prop_type != socket_id
+    if remove_sockets:
+        if has_socket:
+            if isSetter:
+                if "value" in self.inputs:
+                    from .utils import socket_to_type
+                    self.inputs.remove(self.inputs.get("value"))
+            elif "value" in self.outputs:
+                from .utils import socket_to_type
+                self.outputs.remove(self.outputs.get("value"))
+        else:
+            # Path for migrating the old networked variable get/set nodes
+            if isSetter:
+                for i in range(len(self.inputs) - 1, 1, -1):
+                    self.inputs.remove(self.inputs[i])
+            elif len(self.outputs) > 1:
+                for i in range(len(self.outputs) - 1, -1, -1):
+                    self.outputs.remove(self.outputs[i])
 
-    if self.prop_type != prop_type and (self.prop_type != "" and self.prop_type != "None"):
-        for output in self.outputs:
-            for link in output.links:
-                bpy.context.object.bg_active_graph.links.remove(link)
-        for input in self.inputs:
-            for link in input.links:
-                bpy.context.object.bg_active_graph.links.remove(link)
+    if not target:
+        return
 
-    self.prop_type = prop_type
+    # Create a new socket based on the selected variable type
+    from .utils import type_to_socket
+    if var_type != "None" and old_type != var_type:
+        if isSetter:
+            socket = self.inputs.new(type_to_socket[var_type], "value")
+        else:
+            socket = self.outputs.new(type_to_socket[var_type], "value")
+            if var_type == "entity":
+                self.outputs.get("value").target = target.bg_global_variables.get(self.prop_name).defaultEntity
+        if var_type == "entity":
+            socket.refresh = False
+
+    if isSetter:
+        if var and hasattr(var, "networked") and var.networked and var_type != "entity":
+            self.color = get_prefs().network_node_color
+            self.networked = True
+        else:
+            self.networked = False
+
+    self.prop_type = var_type
 
 
-class BGNode_networkedVariable_set(BGActionNode, BGNode, Node):
-    bl_label = "Networked Variable Set"
+def getNetworkedVariableId(self):
+    target = get_input_entity(self, bpy.context)
+    if target and self.prop_name in target.bg_global_variables:
+        return target.bg_global_variables.find(self.prop_name) + 1
+    return 0
+
+
+def setNetworkedVariableId(self, value):
+    target = get_input_entity(self, bpy.context)
+    if not target or value == 0:
+        self.prop_name = 'None'
+    elif value <= len(target.bg_global_variables):
+        self.prop_name = target.bg_global_variables[value - 1].name
+    else:
+        self.prop_name = 'None'
+
+
+class BGNode_networkedVariable_set(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Variable Set"
     node_type = "networkedVariable/set"
 
-    prop_name: bpy.props.EnumProperty(
+    prop_id: bpy.props.EnumProperty(
         name="Property",
         description="Property",
         items=get_available_networkedBehavior_properties,
-        update=networkedBehavior_properties_updated,
+        update=update_selected_networked_variable,
+        get=getNetworkedVariableId,
+        set=setNetworkedVariableId,
         default=0
+    )
+
+    prop_name: bpy.props.StringProperty(
+        name="Property Name",
+        description="Property Name",
+        default="None"
     )
 
     prop_type: bpy.props.StringProperty(default="")
 
+    networked: bpy.props.BoolProperty(default=True, update=update_networked_color)
+
     def init(self, context):
         super().init(context)
-        self.color = (0.2, 0.6, 0.2)
         self.inputs.new("BGHubsEntitySocket", "entity")
         entity = self.inputs.get("entity")
-        entity.poll_components = "networked-behavior"
-        self.inputs.new("NodeSocketBool", "boolean")
-        self.inputs['boolean'].hide = True
-        self.inputs.new("NodeSocketFloat", "float")
-        self.inputs['float'].hide = True
-        self.inputs.new("NodeSocketInt", "integer")
-        self.inputs['integer'].hide = True
-        self.inputs.new("NodeSocketString", "string")
-        self.inputs['string'].hide = True
-        self.inputs.new("NodeSocketVectorXYZ", "vec3")
-        self.inputs['vec3'].hide = True
-        self.inputs.new("NodeSocketVectorXYZ", "color")
-        self.inputs['color'].hide = True
+        entity.custom_type = "event_variable"
+        update_selected_networked_variable(self, context)
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, "prop_name")
+        row = layout.row()
+        row.prop(self, "networked")
+        row.enabled = False
+        layout.prop(self, "prop_id")
 
     def refresh(self):
-        if self.prop_name:
-            self.prop_name = self.prop_name
+        update_selected_networked_variable(self, bpy.context)
 
     def gather_parameters(self, ob, input_socket, export_settings):
-        if self.prop_type == input_socket.identifier:
-            return {
-                "value": get_socket_value(ob, export_settings, input_socket)
-            }
+        return {
+            "value": get_socket_value(ob, export_settings, input_socket)
+        }
 
     def gather_configuration(self, ob, variables, events, export_settings):
-        return {
-            "prop_name": gather_property(export_settings, self, self, "prop_name"),
-            "prop_type": gather_property(export_settings, self, self, "prop_type")
-        }
+        config = super().gather_configuration(ob, variables, events, export_settings)
+        target = get_input_entity(self, bpy.context, ob)
+        if not target:
+            raise Exception("Entity not set")
+        if not object_exists(target):
+            raise Exception(f"Entity {target.name} does not exist")
+        has_prop = self.prop_name in target.bg_global_variables
+        if not has_prop:
+            raise Exception(f"Property {self.prop_name} does not exist")
+        prop = target.bg_global_variables.get(self.prop_name)
+        export_prop_name = self.prop_name if prop.networked else f"{target.name}_{self.prop_name}"
+        config.update({
+            "variableId": variables[export_prop_name]["id"] if not prop.networked else -1,
+            "name": export_prop_name,
+            "valueTypeName": self.prop_type
+        })
+        return config
+
+    def update_network_dependencies(self, ob, export_settings):
+        target = get_input_entity(self, bpy.context, ob)
+        if not target:
+            raise Exception("Entity not set")
+        if not object_exists(target):
+            raise Exception(f"Entity {target.name} does not exist")
+        has_prop = self.prop_name in target.bg_global_variables
+        if not has_prop:
+            raise Exception(f"Property {self.prop_name} does not exist")
+        prop = target.bg_global_variables.get(self.prop_name)
+        if prop.networked:
+            from .utils import update_gltf_network_dependencies, get_variable_value
+            from .components.networked_behavior import NetworkedBehavior
+            value = {
+                self.prop_name: {
+                    "type": prop.type,
+                    "value": get_variable_value(prop, export_settings)
+                }
+            }
+            update_gltf_network_dependencies(self, export_settings, target, NetworkedBehavior, value)
 
 
 class BGNode_networkedVariable_get(BGNode, Node):
-    bl_label = "Networked Variable Get"
+    bl_label = "Variable Get"
     node_type = "networkedVariable/get"
 
     poll_components: StringProperty(default="networked-behavior")
 
-    prop_name: bpy.props.EnumProperty(
+    prop_id: bpy.props.EnumProperty(
         name="Property",
         description="Property",
         items=get_available_networkedBehavior_properties,
-        update=networkedBehavior_properties_updated,
+        update=update_selected_networked_variable,
+        get=getNetworkedVariableId,
+        set=setNetworkedVariableId,
         default=0
+    )
+
+    prop_name: bpy.props.StringProperty(
+        name="Property Name",
+        description="Property Name",
+        default="None"
     )
 
     prop_type: bpy.props.StringProperty(default="")
 
     def init(self, context):
         super().init(context)
-        self.color = (0.2, 0.6, 0.2)
+        self.color = (0.6, 0.6, 0.2)
         self.inputs.new("BGHubsEntitySocket", "entity")
         entity = self.inputs.get("entity")
-        entity.poll_components = "networked-behavior"
-        self.outputs.new("NodeSocketBool", "boolean")
-        self.outputs['boolean'].hide = True
-        self.outputs.new("NodeSocketFloat", "float")
-        self.outputs['float'].hide = True
-        self.outputs.new("NodeSocketInt", "integer")
-        self.outputs['integer'].hide = True
-        self.outputs.new("NodeSocketString", "string")
-        self.outputs['string'].hide = True
-        self.outputs.new("NodeSocketVectorXYZ", "vec3")
-        self.outputs['vec3'].hide = True
-        self.outputs.new("NodeSocketVectorXYZ", "color")
-        self.outputs['color'].hide = True
+        entity.custom_type = "event_variable"
+        update_selected_networked_variable(self, context)
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, "prop_name")
+        layout.prop(self, "prop_id")
 
     def refresh(self):
-        if self.prop_name:
-            self.prop_name = self.prop_name
+        update_selected_networked_variable(self, bpy.context)
 
     def gather_parameters(self, ob, input_socket, export_settings):
-        if self.prop_type == input_socket.identifier:
-            return {
-                "value": get_socket_value(ob, export_settings, input_socket)
-            }
-
-    def gather_configuration(self, ob, variables, events, export_settings):
         return {
-            "prop_name": gather_property(export_settings, self, self, "prop_name"),
-            "prop_type": gather_property(export_settings, self, self, "prop_type")
+            "value": get_socket_value(ob, export_settings, input_socket)
         }
 
-
-SUPPORTED_COMPONENTS = [
-    video.Video.get_name(),
-    audio.Audio.get_name(),
-    text.Text.get_name(),
-    networked_animation.NetworkedAnimation.get_name(),
-    rigid_body.RigidBody.get_name(),
-    physics_shape.PhysicsShape.get_name(),
-    networked_transform.NetworkedTransform.get_name(),
-    networked_behavior.NetworkedBehavior.get_name(),
-    media_frame.MediaFrame.get_name(),
-    visible.Visible.get_name()
-]
+    def gather_configuration(self, ob, variables, events, export_settings):
+        target = get_input_entity(self, bpy.context, ob)
+        if not target:
+            raise Exception("Entity not set")
+        has_prop = self.prop_name in target.bg_global_variables
+        if not has_prop:
+            raise Exception(f"Property {self.prop_name} does not exist")
+        prop = target.bg_global_variables.get(self.prop_name)
+        export_prop_name = self.prop_name if prop.networked else f"{target.name}_{self.prop_name}"
+        return {
+            "networked": prop.networked,
+            "variableId": variables[export_prop_name]["id"] if not prop.networked else -1,
+            "name": export_prop_name,
+            "valueTypeName": self.prop_type
+        }
 
 
 def get_children(ob):
@@ -820,7 +948,7 @@ def getAvailableComponents(self, context):
     registry = get_components_registry()
     getAvailableComponents.cached_enum = [("None", "None", "None")]
 
-    target = get_target(self, context)
+    target = get_input_entity(self, context)
     if target:
         all_object_components = get_object_components(target)
         for component_name, component_class in registry.items():
@@ -841,7 +969,7 @@ def component_updated(self, context):
     self.inputs.get("entity").component = self.component_name
     self.inputs.get("component").default_value = self.component_name
 
-    target = get_target(self, context)
+    target = get_input_entity(self, context)
     self.outputs.get("entity").target = target
 
 
@@ -859,7 +987,7 @@ class BGNode_get_component(BGNode, Node):
 
     def init(self, context):
         super().init(context)
-        self.color = (0.2, 0.6, 0.2)
+        self.color = (0.6, 0.6, 0.2)
         self.inputs.new("BGHubsEntitySocket", "entity")
         component = self.inputs.new("NodeSocketString", "component")
         component.hide = True
@@ -870,7 +998,7 @@ class BGNode_get_component(BGNode, Node):
 
 
 def getComponentId(self):
-    target = get_target(self, bpy.context)
+    target = get_input_entity(self, bpy.context)
     if target:
         components = [item[0] for item in getAvailableComponents(self, bpy.context)]
         if target and self.componentName in components:
@@ -879,7 +1007,7 @@ def getComponentId(self):
 
 
 def setComponentId(self, value):
-    target = get_target(self, bpy.context)
+    target = get_input_entity(self, bpy.context)
     if target:
         components = [item[0] for item in getAvailableComponents(self, bpy.context)]
         if not target or value == 0:
@@ -892,22 +1020,12 @@ def setComponentId(self, value):
         self.componentName = 'None'
 
 
-SUPPORTED_PROPERTY_COMPONENTS = [
-    video.Video.get_name(),
-    audio.Audio.get_name(),
-    text.Text.get_name(),
-    rigid_body.RigidBody.get_name(),
-    media_frame.MediaFrame.get_name(),
-    visible.Visible.get_name(),
-]
-
-
 def getPropertyComponents(self, context):
     from io_hubs_addon.components.components_registry import get_components_registry
     registry = get_components_registry()
     getPropertyComponents.cached_enum = [("None", "None", "None")]
 
-    target = get_target(self, context)
+    target = get_input_entity(self, context)
     if target:
         all_object_components = get_object_components(target)
         for component_name, component_class in registry.items():
@@ -931,7 +1049,7 @@ def getAvailableProperties(self, context):
         component_class = get_component_by_name(self.componentName)
         for property_name in component_class.get_properties():
             component_id = component_class.get_id()
-            target = get_target(self, context)
+            target = get_input_entity(self, context)
             if target:
                 component = getattr(target, component_id)
                 property = component.bl_rna.properties[property_name]
@@ -962,7 +1080,7 @@ def get_component_properties(target, componentName):
 
 
 def getPropertyId(self):
-    target = get_target(self, bpy.context)
+    target = get_input_entity(self, bpy.context)
     if target:
         properties = get_component_properties(target, self.componentName)
         if target and self.propertyName in properties and self.componentName != "None" and self.componentName in target.hubs_component_list.items:
@@ -971,7 +1089,7 @@ def getPropertyId(self):
 
 
 def setPropertyId(self, value):
-    target = get_target(self, bpy.context)
+    target = get_input_entity(self, bpy.context)
     if target:
         if self.componentName not in target.hubs_component_list.items:
             self.propertyName = 'None'
@@ -995,7 +1113,7 @@ def update_set_component_property(self, context):
     if not context:
         return
 
-    target = get_target(self, context)
+    target = get_input_entity(self, context)
     if not target or self.componentName == "None" or self.propertyName == "None" or self.componentName not in target.hubs_component_list.items:
         return
 
@@ -1029,7 +1147,7 @@ def update_set_component_property(self, context):
             socket.default_value = prop_value
 
 
-class BGNode_set_component_property(BGActionNode, BGNode, Node):
+class BGNode_set_component_property(BGNetworked, BGActionNode, BGNode, Node):
     bl_label = "Set Component Property"
     node_type = "components/setComponentProperty"
 
@@ -1067,10 +1185,10 @@ class BGNode_set_component_property(BGActionNode, BGNode, Node):
 
     def init(self, context):
         super().init(context)
-        self.color = (0.2, 0.6, 0.2)
         self.inputs.new("BGHubsEntitySocket", "entity")
 
     def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
         layout.prop(self, "componentId")
         layout.prop(self, "propertyId")
 
@@ -1084,6 +1202,7 @@ class BGNode_set_component_property(BGActionNode, BGNode, Node):
             from .utils import socket_to_type
             prop_type = socket_to_type[self.inputs[2].bl_idname]
             return {
+                "networked": self.networked,
                 "component": gather_property(export_settings, self, self, "componentName"),
                 "property": gather_property(export_settings, self, self, "propertyName"),
                 "type": prop_type
@@ -1098,7 +1217,7 @@ def update_get_component_property(self, context):
     if not context:
         return
 
-    target = get_target(self, context)
+    target = get_input_entity(self, context)
     if not target or self.componentName == "None" or self.propertyName == "None" or self.componentName not in target.hubs_component_list.items:
         return
 
@@ -1170,7 +1289,7 @@ class BGNode_get_component_property(BGNode, Node):
 
     def init(self, context):
         super().init(context)
-        self.color = (0.2, 0.6, 0.2)
+        self.color = (0.6, 0.6, 0.2)
         self.inputs.new("BGHubsEntitySocket", "entity")
 
     def draw_buttons(self, context, layout):
@@ -1186,3 +1305,257 @@ class BGNode_get_component_property(BGNode, Node):
                 "property": gather_property(export_settings, self, self, "propertyName"),
                 "type": prop_type
             }
+
+
+def get_material_socket_value(socket, context):
+    value = None
+    if socket:
+        if socket.is_linked and len(socket.links) > 0:
+            link = socket.links[0]
+            from_node = link.from_socket.node
+            entity = get_input_entity(from_node, context)
+            if len(entity.material_slots) > 0:
+                value = entity.material_slots[0].material
+        else:
+            value = socket.default_value
+
+    return value
+
+
+class BGNode_set_material(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Set Material"
+    node_type = "material/set"
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("BGHubsEntitySocket", "entity")
+        self.inputs.new("NodeSocketMaterial", "material")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
+
+    def update_network_dependencies(self, ob, export_settings):
+        if self.networked:
+            target = get_input_entity(self, bpy.context, ob)
+            if not target:
+                raise Exception("Entity not set")
+            if not object_exists(target):
+                raise Exception(f"Entity {target.name} does not exist")
+            material = get_material_socket_value(self.inputs.get("material"), bpy.context)
+            if not material:
+                raise Exception("Material not set")
+            from .utils import update_gltf_network_dependencies
+            from .components import networked_object_material
+            from .components import networked_material
+            update_gltf_network_dependencies(self, export_settings, target,
+                                             networked_object_material.NetworkedObjectMaterial)
+            update_gltf_network_dependencies(self, export_settings, material, networked_material.NetworkedMaterial)
+
+
+def update_set_material_property(self, context):
+    # Remove previous socket
+    if self.inputs and len(self.inputs) > 2:
+        self.inputs.remove(self.inputs[2])
+
+    # Create a new socket based on the selected variable type
+    from .utils import type_to_socket
+    self.inputs.new(type_to_socket[MATERIAL_PROPERTIES_TO_TYPES[self.property_name]], self.property_name)
+
+
+class BGNode_set_material_property(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Set Material Property"
+    node_type = "material/property/set"
+
+    property_name: bpy.props.EnumProperty(
+        name="Property",
+        description="Property",
+        items=MATERIAL_PROPERTIES_ENUM,
+        update=update_set_material_property,
+        default="color"
+    )
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("NodeSocketMaterial", "material")
+        update_set_material_property(self, context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
+        layout.prop(self, "property_name")
+
+    def gather_configuration(self, ob, variables, events, export_settings):
+        config = super().gather_configuration(ob, variables, events, export_settings)
+        config.update({
+            "property": gather_property(export_settings, self, self, "property_name"),
+            "type": MATERIAL_PROPERTIES_TO_TYPES[self.property_name]
+        })
+        return config
+
+    def update_network_dependencies(self, ob, export_settings):
+        if self.networked:
+            material = get_material_socket_value(self.inputs.get("material"), bpy.context)
+            if not material:
+                raise Exception("Material not set")
+            from .utils import update_gltf_network_dependencies
+            from .components import networked_material
+            update_gltf_network_dependencies(self, export_settings, material, networked_material.NetworkedMaterial)
+
+
+def update_get_material_property(self, context):
+    # Remove previous socket
+    if self.outputs and len(self.outputs) > 0:
+        self.outputs.remove(self.outputs[0])
+
+    # Create a new socket based on the selected variable type
+    from .utils import type_to_socket
+    self.outputs.new(type_to_socket[MATERIAL_PROPERTIES_TO_TYPES[self.property_name]], self.property_name)
+
+
+class BGNode_get_material_property(BGNode, Node):
+    bl_label = "Get Material Property"
+    node_type = "material/property/get"
+
+    property_name: bpy.props.EnumProperty(
+        name="Property",
+        description="Property",
+        items=MATERIAL_PROPERTIES_ENUM,
+        update=update_get_material_property,
+        default="color"
+    )
+
+    def init(self, context):
+        super().init(context)
+        self.color = (0.6, 0.6, 0.2)
+        self.inputs.new("NodeSocketMaterial", "material")
+        update_get_material_property(self, context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "property_name")
+
+    def gather_configuration(self, ob, variables, events, export_settings):
+        return {
+            "networked": self.networked,
+            "property": gather_property(export_settings, self, self, "property_name"),
+            "type": MATERIAL_PROPERTIES_TO_TYPES[self.property_name]
+        }
+
+
+class BGNode_media_mediaPlayback(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Media Playback"
+    node_type = "media/mediaPlayback"
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("BGHubsEntitySocket", "entity")
+        from .sockets import BGFlowSocket
+        BGFlowSocket.create(self.inputs, name="play")
+        BGFlowSocket.create(self.inputs, name="pause")
+        BGFlowSocket.create(self.inputs, name="setMuted")
+        self.inputs.new("NodeSocketBool", "muted")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
+
+
+class BGNode_media_frame_setMediaFrameProperty(BGNetworked, BGNode, Node):
+    bl_label = "Set Media Frame Property"
+    node_type = "media_frame/setMediaFrameProperty"
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("BGHubsEntitySocket", "entity")
+        from .sockets import BGFlowSocket
+        BGFlowSocket.create(self.inputs, name="setActive")
+        self.inputs.new("NodeSocketBool", "active")
+        BGFlowSocket.create(self.inputs, name="setLocked")
+        self.inputs.new("NodeSocketBool", "locked")
+        BGFlowSocket.create(self.outputs)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
+
+
+class BGNode_animation_createAnimationAction(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Create AnimationAction"
+    node_type = "animation/createAnimationAction"
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("BGHubsEntitySocket", "entity")
+        self.inputs.new("NodeSocketString", "clipName")
+        self.inputs.new("NodeSocketBool", "loop")
+        self.inputs.new("NodeSocketBool", "clampWhenFinished")
+        self.inputs.new("NodeSocketFloat", "weight")
+        self.inputs.new("NodeSocketFloat", "timeScale")
+        self.inputs.new("NodeSocketBool", "additiveBlending")
+        self.outputs.new("BGHubsAnimationActionSocket", "action")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
+
+    def update_network_dependencies(self, ob, export_settings):
+        if self.networked:
+            target = get_input_entity(self, bpy.context, ob)
+            if not target:
+                raise Exception("Entity not set")
+            if not object_exists(target):
+                raise Exception(f"Entity {target.name} does not exist")
+            from .utils import update_gltf_network_dependencies
+            from .components import networked_animation
+            update_gltf_network_dependencies(self, export_settings, target, networked_animation.NetworkedAnimation)
+
+
+class BGNode_animation_play(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Play Animation"
+    node_type = "animation/play"
+
+    def init(self, context):
+        super().init(context)
+        from .sockets import BGFlowSocket
+        self.inputs.new("BGHubsAnimationActionSocket", "action")
+        self.inputs.new("NodeSocketBool", "reset")
+        BGFlowSocket.create(self.outputs, name="finished")
+        BGFlowSocket.create(self.outputs, name="loop")
+        BGFlowSocket.create(self.outputs, name="stopped")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
+
+
+class BGNode_animation_stop(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Stop Animation"
+    node_type = "animation/stop"
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("BGHubsAnimationActionSocket", "action")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
+
+
+class BGNode_animation_crossfadeTo(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Crossfade To Animation"
+    node_type = "animation/crossfadeTo"
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("BGHubsAnimationActionSocket", "action")
+        self.inputs.new("BGHubsAnimationActionSocket", "toAction")
+        self.inputs.new("NodeSocketFloat", "duration")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")
+
+
+class BGNode_three_animation_setTimescale(BGNetworked, BGActionNode, BGNode, Node):
+    bl_label = "Set timeScale"
+    node_type = "three/animation/setTimescale"
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("BGHubsAnimationActionSocket", "action")
+        self.inputs.new("NodeSocketFloat", "timeScale")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "networked")

--- a/nodespec.json
+++ b/nodespec.json
@@ -4903,7 +4903,7 @@
         "defaultValue": 0
       },
       {
-        "name": "string",
+        "name": "value",
         "valueType": "string",
         "defaultValue": ""
       }
@@ -4929,7 +4929,7 @@
     ],
     "outputs": [
       {
-        "name": "string",
+        "name": "value",
         "valueType": "string"
       }
     ],
@@ -5546,6 +5546,81 @@
           "y": -9.8,
           "z": 0
         }
+      }
+    ],
+    "outputs": [
+      {
+        "name": "flow",
+        "valueType": "flow"
+      }
+    ],
+    "configuration": []
+  },
+  {
+    "type": "material/property/set",
+    "category": "Materials",
+    "label": "Set Material Property",
+    "inputs": [
+      {
+        "name": "flow",
+        "valueType": "flow"
+      },
+      {
+        "name": "material",
+        "valueType": "material",
+        "defaultValue": null
+      },
+      {
+        "name": "string",
+        "valueType": "string",
+        "defaultValue": ""
+      }
+    ],
+    "outputs": [
+      {
+        "name": "flow",
+        "valueType": "flow"
+      }
+    ],
+    "configuration": []
+  },
+  {
+    "type": "material/property/get",
+    "category": "Materials",
+    "label": "Get Material Property",
+    "inputs": [
+      {
+        "name": "material",
+        "valueType": "material",
+        "defaultValue": null
+      }
+    ],
+    "outputs": [
+      {
+        "name": "string",
+        "valueType": "string"
+      }
+    ],
+    "configuration": []
+  },
+  {
+    "type": "material/set",
+    "category": "Materials",
+    "label": "Set Material",
+    "inputs": [
+      {
+        "name": "flow",
+        "valueType": "flow"
+      },
+      {
+        "name": "entity",
+        "valueType": "entity",
+        "defaultValue": 0
+      },
+      {
+        "name": "material",
+        "valueType": "material",
+        "defaultValue": null
       }
     ],
     "outputs": [

--- a/sockets.py
+++ b/sockets.py
@@ -107,6 +107,18 @@ class BGHubsEntitySocket(NodeSocketStandard):
                 return {
                     "value": gather_object_property(export_settings, ob)
                 }
+            elif self.entity_type == "other":
+                if self.target:
+                    if self.target.name not in bpy.context.view_layer.objects:
+                        raise Exception(f"Entity {self.target.name} does not exist")
+                    else:
+                        return {
+                            "value": gather_object_property(export_settings, self.target)
+                        }
+                else:
+                    return {
+                        "value": gather_object_property(export_settings, self.target)
+                    }
             elif self.target:
                 if self.target.name not in bpy.context.view_layer.objects:
                     raise Exception(f"Entity {self.target.name} does not exist")

--- a/ui.py
+++ b/ui.py
@@ -1,7 +1,9 @@
 import bpy
 from bpy.types import PropertyGroup, NodeTree
 from bpy.props import PointerProperty, CollectionProperty, IntProperty, EnumProperty, StringProperty, FloatProperty, BoolProperty, FloatVectorProperty
-from bpy.app.handlers import persistent
+from bpy.types import AddonPreferences
+from .consts import CATEGORY_COLORS
+from .utils import update_nodes, get_prefs
 
 original_NODE_HT_header_draw = bpy.types.NODE_HT_header.draw
 
@@ -126,47 +128,6 @@ class BGAddSlot(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class BGObjectPanel(bpy.types.Panel):
-    bl_label = "Behavior Graphs"
-    bl_idname = "OBJECT_PT_BG"
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_context = "object"
-
-    def draw(self, context):
-        layout = self.layout
-        row = layout.row()
-        row.template_list(BGNodeTreeList.bl_idname, "", context.object,
-                          "bg_slots", context.object, "bg_active_slot_idx", rows=5)
-        col = row.column(align=True)
-        col.context_pointer_set('target', context.object)
-        col.operator(BGAddSlot.bl_idname, icon='ADD', text="")
-        col.operator(BGRemove.bl_idname, icon='REMOVE', text="")
-        row = layout.row()
-        row.context_pointer_set("target", context.object)
-        row.template_ID(context.object, "bg_active_graph", new=BGNew.bl_idname, unlink=BGRemove.bl_idname)
-
-        row = layout.row()
-        row.label(text="Variables:")
-        row = layout.row()
-        row.template_list(BGGlobalVariablesList.bl_idname, "", context.object,
-                          "bg_global_variables", context.object, "bg_active_global_variable_idx", rows=5)
-        col = row.column(align=True)
-        col.context_pointer_set('target', context.object)
-        col.operator(BGGlobalVariableAdd.bl_idname, icon='ADD', text="")
-        col.operator(BGGlobalVariableRemove.bl_idname, icon='REMOVE', text="")
-
-        row = layout.row()
-        row.label(text="Custom Events:")
-        row = layout.row()
-        row.template_list(BGCustomEventsList.bl_idname, "", context.object,
-                          "bg_custom_events", context.object, "bg_active_custom_event_idx", rows=5)
-        col = row.column(align=True)
-        col.context_pointer_set('target', context.object)
-        col.operator(BGCustomEventAdd.bl_idname, icon='ADD', text="")
-        col.operator(BGCustomEventRemove.bl_idname, icon='REMOVE', text="")
-
-
 GLOBAL_VARIABLES_TYPES = [
     ("boolean", "Boolean", "Boolean"),
     ("float", "Float", "Float"),
@@ -177,24 +138,6 @@ GLOBAL_VARIABLES_TYPES = [
     ("entity", "Entity", "Entity"),
     ("color", "Color", "Color"),
 ]
-
-
-def update_nodes(self, context):
-    if hasattr(context.object, "bg_active_graph") and context.object.bg_active_graph != None:
-        for node in context.object.bg_active_graph.nodes:
-            if hasattr(node, "refresh") and callable(getattr(node, "refresh")):
-                node.refresh()
-    if hasattr(context.scene, "bg_active_graph") and context.scene.bg_active_graph != None:
-        for node in context.scene.bg_active_graph.nodes:
-            if hasattr(node, "refresh") and callable(getattr(node, "refresh")):
-                node.refresh()
-
-
-def update_graphs(self, context):
-    if hasattr(context.object, "bg_active_graph") and context.object.bg_active_graph != None:
-        context.object.bg_active_graph.update()
-    if hasattr(context.scene, "bg_active_graph") and context.scene.bg_active_graph != None:
-        context.scene.bg_active_graph.update()
 
 
 class BGGlobalVariableType(PropertyGroup):
@@ -243,10 +186,10 @@ class BGGlobalVariableType(PropertyGroup):
         default=(0.0, 0.0, 0.0)
     )
 
-    defaultAnimationAction: IntProperty(
+    defaultAnimationAction: StringProperty(
         name="default",
         description="Default Value",
-        default=0
+        default=""
     )
 
     defaultColor: FloatVectorProperty(
@@ -260,6 +203,13 @@ class BGGlobalVariableType(PropertyGroup):
     )
 
     defaultEntity: PointerProperty(name="default", type=bpy.types.Object)
+
+    networked: BoolProperty(
+        name="networked",
+        description="Networked",
+        update=update_nodes,
+        default=False
+    )
 
 
 class BGGlobalVariableAdd(bpy.types.Operator):
@@ -297,7 +247,11 @@ class BGGlobalVariablesList(bpy.types.UIList):
     bl_label = "Variables"
 
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        split = layout.split(align=True)
+        disable_networked = False
+        from .behavior_graph import BGTree
+        if type(data) == bpy.types.Scene or type(data) == BGTree:
+            disable_networked = True
+        split = layout.split(align=False)
         split.prop(item, "name", text="", emboss=False, icon='NONE')
         split.prop(item, "type", text="", emboss=False, icon='NONE')
         if item.type == "integer":
@@ -314,6 +268,12 @@ class BGGlobalVariablesList(bpy.types.UIList):
             split.prop(item, "defaultColor", text="", emboss=True, icon='NONE')
         elif item.type == "entity":
             split.prop(item, "defaultEntity", text="", emboss=True, icon='NONE')
+        elif item.type == "animationAction":
+            split.prop(item, "defaultAnimationAction", text="", emboss=True, icon='NONE')
+        split = layout.split(align=False)
+        split.prop(item, "networked", text="", emboss=True, icon='NONE')
+        if item.type == "entity" or disable_networked:
+            split.enabled = False
 
 
 class BGCustomEventType(PropertyGroup):
@@ -362,6 +322,80 @@ class BGCustomEventsList(bpy.types.UIList):
         split.prop(item, "name", text="", emboss=False, icon='NONE')
 
 
+def draw_bg_panel(self, target):
+    layout = self.layout
+
+    if type(target) in [bpy.types.Object, bpy.types.Scene]:
+        row = layout.row()
+        row.template_list(BGNodeTreeList.bl_idname, "", target,
+                          "bg_slots", target, "bg_active_slot_idx", rows=5)
+        col = row.column(align=True)
+        col.context_pointer_set('target', target)
+        col.operator(BGAddSlot.bl_idname, icon='ADD', text="")
+        col.operator(BGRemove.bl_idname, icon='REMOVE', text="")
+        row = layout.row()
+        row.context_pointer_set("target", target)
+        row.template_ID(target, "bg_active_graph", new=BGNew.bl_idname, unlink=BGRemove.bl_idname)
+
+    row = layout.row()
+    col = row.column(align=True)
+    op = col.operator(BGSetNetworkGraph.bl_idname, text="Network Graph")
+    op.set = True
+    op.all = False
+    col = row.column(align=True)
+    op = col.operator(BGSetNetworkGraph.bl_idname, text="De-Network Graph")
+    op.set = False
+    op.all = False
+    row = layout.row()
+    col = row.column(align=True)
+    op = col.operator(BGSetNetworkGraph.bl_idname, text="Network All Graphs")
+    op.set = True
+    op.all = True
+    col = row.column(align=True)
+    op = col.operator(BGSetNetworkGraph.bl_idname, text="De-Network All Graphs")
+    op.set = False
+    op.all = True
+
+    row = layout.row()
+    row.label(text="Node colors:")
+    box = layout.box()
+    row = box.row()
+    row.prop(get_prefs(), "network_node_color")
+    row = box.row()
+    row.operator(BGUpdateNodeColors.bl_idname, text="Update Graph Node Colors")
+
+    row = layout.row()
+    row.label(text="Variables:")
+    row = layout.row()
+    row.template_list(BGGlobalVariablesList.bl_idname, "", target,
+                      "bg_global_variables", target, "bg_active_global_variable_idx", rows=5)
+    col = row.column(align=True)
+    col.context_pointer_set('target', target)
+    col.operator(BGGlobalVariableAdd.bl_idname, icon='ADD', text="")
+    col.operator(BGGlobalVariableRemove.bl_idname, icon='REMOVE', text="")
+
+    row = layout.row()
+    row.label(text="Custom Events:")
+    row = layout.row()
+    row.template_list(BGCustomEventsList.bl_idname, "", target,
+                      "bg_custom_events", target, "bg_active_custom_event_idx", rows=5)
+    col = row.column(align=True)
+    col.context_pointer_set('target', target)
+    col.operator(BGCustomEventAdd.bl_idname, icon='ADD', text="")
+    col.operator(BGCustomEventRemove.bl_idname, icon='REMOVE', text="")
+
+
+class BGObjectPanel(bpy.types.Panel):
+    bl_label = "Behavior Graphs"
+    bl_idname = "OBJECT_PT_BG"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "object"
+
+    def draw(self, context):
+        draw_bg_panel(self, context.object)
+
+
 class BGScenePanel(bpy.types.Panel):
     bl_label = 'Behavior Graphs'
     bl_idname = "SCENE_PT_BG"
@@ -370,38 +404,22 @@ class BGScenePanel(bpy.types.Panel):
     bl_context = 'scene'
 
     def draw(self, context):
-        layout = self.layout
+        draw_bg_panel(self, context.scene)
 
-        row = layout.row()
-        row.template_list(BGNodeTreeList.bl_idname, "", context.scene,
-                          "bg_slots", context.scene, "bg_active_slot_idx", rows=5)
-        col = row.column(align=True)
-        col.context_pointer_set('target', context.scene)
-        col.operator(BGAddSlot.bl_idname, icon='ADD', text="")
-        col.operator(BGRemove.bl_idname, icon='REMOVE', text="")
-        row = layout.row()
-        row.context_pointer_set("target", context.scene)
-        row.template_ID(context.scene, "bg_active_graph", new=BGNew.bl_idname, unlink=BGRemove.bl_idname)
 
-        row = layout.row()
-        row.label(text="Variables:")
-        row = layout.row()
-        row.template_list(BGGlobalVariablesList.bl_idname, "", context.scene,
-                          "bg_global_variables", context.scene, "bg_active_global_variable_idx", rows=5)
-        col = row.column(align=True)
-        col.context_pointer_set('target', context.scene)
-        col.operator(BGGlobalVariableAdd.bl_idname, icon='ADD', text="")
-        col.operator(BGGlobalVariableRemove.bl_idname, icon='REMOVE', text="")
+class BG_PT_GraphPanel(bpy.types.Panel):
+    bl_space_type = "NODE_EDITOR"
+    bl_region_type = "UI"
+    bl_label = "Behavior Graphs"
+    bl_category = "Behavior Graphs"
+    bl_context = "scene"
 
-        row = layout.row()
-        row.label(text="Custom Events:")
-        row = layout.row()
-        row.template_list(BGCustomEventsList.bl_idname, "", context.scene,
-                          "bg_custom_events", context.scene, "bg_active_custom_event_idx", rows=5)
-        col = row.column(align=True)
-        col.context_pointer_set('target', context.scene)
-        col.operator(BGCustomEventAdd.bl_idname, icon='ADD', text="")
-        col.operator(BGCustomEventRemove.bl_idname, icon='REMOVE', text="")
+    def draw(self, context):
+        graph = get_active_graph(context)
+        if not graph:
+            return
+
+        draw_bg_panel(self, graph)
 
 
 def indexForBGItem(slots, graph):
@@ -432,50 +450,80 @@ def bg_active_slot_update(self, context):
         self.bg_active_slot_idx = idx
 
 
-class BGGraphPanel(bpy.types.Panel):
-    bl_space_type = "NODE_EDITOR"
-    bl_region_type = "UI"
-    bl_label = "Behavior Graphs"
-    bl_category = "Behavior Graphs"
-    bl_context = "scene"
+def get_active_graph(context):
+    if context.scene.bg_node_type == 'OBJECT':
+        target = context.active_object
+    else:
+        target = context.scene
 
-    def draw(self, context):
-        layout = self.layout
+    if not hasattr(target, "bg_active_graph") or not target.bg_active_graph:
+        return
 
-        if context.scene.bg_node_type == 'OBJECT':
-            target = context.active_object
+    return target.bg_active_graph
+
+
+class BGSetNetworkGraph(bpy.types.Operator):
+    bl_idname = "ui.bg_set_network_graph"
+    bl_label = "Network"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    set: BoolProperty(default=True)
+    all: BoolProperty(default=False)
+
+    def execute(self, context):
+        def network_graph(graph):
+            for node in graph.nodes:
+                if hasattr(node, "networked"):
+                    node.networked = self.set
+
+        if self.all:
+            for graph in [group for group in bpy.data.node_groups if group.bl_idname == "BGTree"]:
+                network_graph(graph)
         else:
-            target = context.scene
+            graph = get_active_graph(context)
+            if graph:
+                network_graph(graph)
 
-        if not hasattr(target, "bg_active_graph") or not target.bg_active_graph:
-            return
+        return {'FINISHED'}
 
-        row = layout.row()
-        row.label(text="Variables:")
-        row = layout.row()
-        row.template_list(BGGlobalVariablesList.bl_idname, "", target.bg_active_graph,
-                          "bg_global_variables", target.bg_active_graph, "bg_active_global_variable_idx", rows=5)
-        col = row.column(align=True)
-        col.context_pointer_set('target', target.bg_active_graph)
-        col.operator(BGGlobalVariableAdd.bl_idname, icon='ADD', text="")
-        col.operator(BGGlobalVariableRemove.bl_idname, icon='REMOVE', text="")
 
-        row = layout.row()
-        row.label(text="Events:")
-        row = layout.row()
-        row.template_list(BGCustomEventsList.bl_idname, "", target.bg_active_graph,
-                          "bg_custom_events", target.bg_active_graph, "bg_active_custom_event_idx", rows=5)
-        col = row.column(align=True)
-        col.context_pointer_set('target', target.bg_active_graph)
-        col.operator(BGCustomEventAdd.bl_idname, icon='ADD', text="")
-        col.operator(BGCustomEventRemove.bl_idname, icon='REMOVE', text="")
+class BGUpdateNodeColors(bpy.types.Operator):
+    bl_idname = "ui.bg_update_node_colors"
+    bl_label = "Update Node Colors"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        update_nodes(self, context)
+
+        return {'FINISHED'}
 
 
 class BGItem(PropertyGroup):
     graph: PointerProperty(type=NodeTree)
 
 
+class BGPreferences(AddonPreferences):
+    bl_idname = __package__
+
+    network_node_color: FloatVectorProperty(name="Network",
+                                            description="Color",
+                                            subtype='COLOR_GAMMA',
+                                            default=CATEGORY_COLORS["Networking"],
+                                            size=3,
+                                            min=0,
+                                            max=1)
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.label(text="Node colors:")
+        box = layout.box()
+        row = box.row()
+        row.prop(self, "network_node_color")
+
+
 def register():
+    bpy.utils.register_class(BGPreferences)
     bpy.utils.register_class(BGNew)
     bpy.utils.register_class(BGRemove)
     bpy.utils.register_class(BGAddSlot)
@@ -490,7 +538,9 @@ def register():
     bpy.utils.register_class(BGCustomEventAdd)
     bpy.utils.register_class(BGCustomEventRemove)
     bpy.utils.register_class(BGCustomEventsList)
-    bpy.utils.register_class(BGGraphPanel)
+    bpy.utils.register_class(BG_PT_GraphPanel)
+    bpy.utils.register_class(BGSetNetworkGraph)
+    bpy.utils.register_class(BGUpdateNodeColors)
 
     bpy.utils.register_class(BGItem)
     bpy.types.Object.bg_slots = CollectionProperty(type=BGItem)
@@ -549,7 +599,7 @@ def register():
 
 
 def unregister():
-    bpy.utils.unregister_class(BGGraphPanel)
+    bpy.utils.unregister_class(BG_PT_GraphPanel)
     bpy.utils.unregister_class(BGNew)
     bpy.utils.unregister_class(BGRemove)
     bpy.utils.unregister_class(BGAddSlot)
@@ -564,12 +614,17 @@ def unregister():
     bpy.utils.unregister_class(BGCustomEventAdd)
     bpy.utils.unregister_class(BGCustomEventRemove)
     bpy.utils.unregister_class(BGCustomEventsList)
+    bpy.utils.unregister_class(BGSetNetworkGraph)
+    bpy.utils.unregister_class(BGUpdateNodeColors)
+    bpy.utils.unregister_class(BGPreferences)
 
     del bpy.types.Object.bg_slots
     del bpy.types.Object.bg_active_graph
     del bpy.types.Object.bg_active_slot_idx
     del bpy.types.Object.bg_global_variables
     del bpy.types.Object.bg_active_global_variable_idx
+    del bpy.types.Object.bg_custom_events
+    del bpy.types.Object.bg_active_custom_event_idx
     del bpy.types.Scene.bg_slots
     del bpy.types.Scene.bg_active_graph
     del bpy.types.Scene.bg_active_slot_idx
@@ -578,6 +633,10 @@ def unregister():
     del bpy.types.Scene.bg_active_global_variable_idx
     del bpy.types.Scene.bg_custom_events
     del bpy.types.Scene.bg_active_custom_event_idx
+    del bpy.types.NodeTree.bg_global_variables
+    del bpy.types.NodeTree.bg_active_global_variable_idx
+    del bpy.types.NodeTree.bg_custom_events
+    del bpy.types.NodeTree.bg_active_custom_event_idx
     bpy.utils.unregister_class(BGItem)
 
     bpy.types.NODE_HT_header.draw = original_NODE_HT_header_draw

--- a/ui.py
+++ b/ui.py
@@ -206,7 +206,7 @@ class BGGlobalVariableType(PropertyGroup):
 
     networked: BoolProperty(
         name="networked",
-        description="Networked",
+        description="If checked this variable will be Networked",
         update=update_nodes,
         default=False
     )

--- a/utils.py
+++ b/utils.py
@@ -224,7 +224,7 @@ def get_variable_value(var, export_settings):
     elif var.type == "string":
         value = var.defaultString
     elif var.type == "vec3":
-        default = gather_vec_property(export_settings, var, var, "defaultVec3")
+        value = gather_vec_property(export_settings, var, var, "defaultVec3")
     elif var.type == "animationAction":
         value = var.defaultAnimationAction
     elif var.type == "color":

--- a/utils.py
+++ b/utils.py
@@ -213,7 +213,7 @@ def get_socket_value(ob, export_settings, socket: NodeSocket):
         return None
 
 
-def get_variable_value(var, export_settings):
+def get_variable_value(ob, var, export_settings):
     value = None
     if var.type == "integer":
         value = var.defaultInt
@@ -230,10 +230,12 @@ def get_variable_value(var, export_settings):
     elif var.type == "color":
         value = gather_color_property(export_settings, var, var, "defaultColor", "COLOR_GAMMA")
     elif var.type == "entity":
-        if var.defaultEntity.name not in bpy.context.view_layer.objects:
-            raise Exception(f"Entity {var.defaultEntity.name} does not exist")
-        else:
-            value = gather_property(export_settings, var, var, "defaultEntity")
+        if var.defaultEntity:
+            if var.defaultEntity.name in bpy.context.view_layer.objects:
+                value = gather_property(export_settings, var, var, "defaultEntity")
+            else:
+                raise Exception(
+                    f"Variable {ob.name}/{var.name} entity {var.defaultEntity.name} does not exist in the scene")
 
     return value
 


### PR DESCRIPTION
## Updates
➡️ **Local/Global Variables**
Local/Global Variables have been unified and now they are all managed through the variables panel.
To make a variable networked you just need to enable the "Networked" checkbox in variable item in the variable list. Only object variables can be networked.
The old `Networked Behavior` component has been hidden and you don't need to add it anymore to add networked variables just add the variable in the global variables panel and enable the "Networked" checkbox.
Default entity variables can now be left empty.
Entity variables can be set to an empty entity.
![variables_1](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/e567dd4a-8e07-4f6a-ac70-1ed5882950d4)
![variables_2](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/05b71254-4e05-4656-beb6-456093a9faa1)

➡️ **Networked checkbox**
Nodes that support being networked have now a "Networked" checkbox. This checkbox does two things:
1) Automatically adds the required components to the right objects so the component is networked
2) Automatically takes ownership of the right entity when the node is executed
![Networked_checkbox](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/ba7f739a-dd55-4978-91bd-91dda547de6c)

So you don't need to do `Get Component -> Take Ownership -> Execute Node` anymore, checking the "Networked" checkbox handled that for you.

➡️ **Networked components deprecation** 
All the components that are no longer needed to be added manually have been removed from the components list. You might still see them in the list if you have already added using a previous add-on version but you won't be able to add them anymore.
![networked_components](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/00717a6d-5f4b-4f01-8a9f-92dd9a467e61)

➡️ **Unified Material Properties node**
The multiple material property set nodes have been replaced by a unified node that you can use to set any material property. Old nodes will still run but you can't add them to the graph anymore and they will be removed in the future.
![unified_materia_properties](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/ead668f1-84db-4bea-9a4a-44a2a8880450)

➡️ **Networking nodes color update button**
You can update the color of all the networked nodes using this button.
![Screenshot 2023-11-16 at 10 44 04](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/cacf8ffd-d1d2-4fa2-ad90-2b56cdc5c66c)

➡️ **Better error feedback**
Now we report most of the export errors at export time using the report panel. If you see anything that we don't report and crashes let me know as we might be able to add that warning.
![Screenshot 2023-11-16 at 10 44 47](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/06513ce1-cbcd-4116-aea8-f3efee9d049f)

➡️ **Lots of bug fixes and UI improvements**
A myriad of other minor bug fixes and improvements.

## Breaking changes
Some nodes have changed internally and won't export correctly. You'll need to remove the current nodes and replace them with the new nodes:
- `Networked Variable Get/Set` nodes have been updated internally and 
- Event nodes for `Entity events`, `Player events` and `Trigger events` have been updated so an input entity can be selected so you might need to delete and add those too.