### PR TITLE
Add support for custom events parameters

### DIFF
--- a/consts.py
+++ b/consts.py
@@ -149,3 +149,15 @@ SUPPORTED_PROPERTY_COMPONENTS = [
     media_frame.MediaFrame.get_name(),
     visible.Visible.get_name(),
 ]
+
+VARIABLES_TYPES = [
+    ("boolean", "Boolean", "Boolean"),
+    ("float", "Float", "Float"),
+    ("integer", "Integer", "Integer"),
+    ("string", "String", "String"),
+    ("vec3", "Vector3", "Vector3"),
+    ("animationAction", "Action", "Action"),
+    ("entity", "Entity", "Entity"),
+    ("color", "Color", "Color"),
+    ("material", "Material", "Material")
+]


### PR DESCRIPTION
This PR adds support for parameters in local custom events.

To add parameters to an event:
- Create an event in the events panel for either the scene, an object or a graph clicking on the `+` button
- A parameters panel will appear under the events panel
- Add a new parameter to the event clicking on the `+` button
- Set the parameter type and the default value
- 
![Screenshot 2023-11-23 at 15 59 37](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/71e80304-832d-4bdf-83d3-2419d36be881)

Then you can use the event parameters in the `Trigger` and `OnTrigger` nodes:

![Screenshot 2023-11-23 at 16 02 43](https://github.com/MozillaReality/blender-gltf-behavior-graph/assets/837184/020f9417-90a1-4512-b6ad-bd8adea7de0f)

You can add as many parameters as you want to build functions that you can reuse.