### PR TITLE
Remove snapping options in Behavior Graph editor header for Blender 4.4

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ bl_info = {
     "blender": (3, 2, 0),
     "category": "Node",
     "author": "netpro2k, keianhzo",
-    "version": (0, 0, 3),
+    "version": (0, 0, 4),
     "location": "Node Editor > Sidebar > Behavior Graph",
     "description": "Create and export GLTF KHR_behavior graphs using Blender's node group editor"
 }

--- a/ui.py
+++ b/ui.py
@@ -46,9 +46,10 @@ def draw_header(self, context):
         # Snap
         row = layout.row(align=True)
         row.prop(tool_settings, "use_snap_node", text="")
-        row.prop(tool_settings, "snap_node_element", icon_only=True)
-        if tool_settings.snap_node_element != 'GRID':
-            row.prop(tool_settings, "snap_target", text="")
+        if bpy.app.version < (4, 4, 0):
+            row.prop(tool_settings, "snap_node_element", icon_only=True)
+            if tool_settings.snap_node_element != 'GRID':
+                row.prop(tool_settings, "snap_target", text="")
 
         # Overlay toggle & popover
         row = layout.row(align=True)


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Removes the UI in the Behavior Graph editor's header for the snapping settings and modes for Blender 4.4.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
These settings were removed globally in the Blender 4.4 release and attempting to use them caused Python errors and prevented the user from adding Behavior Graph nodes.

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->
Before:
![2025-06-17_03-47](https://github.com/user-attachments/assets/f80393d9-0f07-43eb-ba40-7613fd72a9b8)

After:
![2025-06-17_03-48](https://github.com/user-attachments/assets/030baacb-4812-4e2c-bd44-e5d184333245)

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Open Blender 4.4 from a terminal.
2. Switch one of your editors to a Behavior Graphs editor.
3. Add a new Behavior Graph.
4. Add a node to that Behavior Graph.
5. See that the node isn't greyed out and can be added (the opposite is true without this PR).
6. See that there are no errors in the terminal.
7. See that the snapping options in the header UI match those of the other node editors.
8. Repeat the above steps for a Blender version below 4.4, e.g. 4.2, 3.6, etc.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
No documentation updates are needed because this pull request updates the add-on's UI to be consistent with the other node editors in Blender 4.4.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
None known.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
None.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
This change keeps the Behavior Graph editor header UI matched with the rest of the Node editors and leaves only the toggle to enable/disable snapping for Blender 4.4.  See this commit for more details - https://projects.blender.org/blender/blender/commit/35ea495bb6ef3aea658f38c00131ef4ddbedb3c5

The additional settings are still present for lower Blender versions.
